### PR TITLE
Build a docker images with a tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 env:
   global:
-  - DOCKER_IMAGE=goobox/docker-sia:latest
+  - DOCKER_IMAGE=goobox/docker-sia
   - secure: JFlbXF5GE0T63F6Dpd9EWfkrBcJZOSp+cctHCTu/d2JkqHNLtN5J8tPDDZwZZT9BTvV/05i9aZcvx3/cDsgVn1bMDqxApVFVcEvKaSYYk9HQ7YROyxKpfT8xiB0tyKauCaLEaEIRPL4yFM1cv4Gm3v9ZhkDBcilUaJx++Sim/o+HBOn8VYud0+OBA8qUos5mo4+u9fGk65eQzgI31Sg/a3udwARplrJnvUh+6sshNxhRmj2cCdwfNbBB5oOOS9LEgrY8sC4HNH9FirfO2sey+t6wOTANQIBQvFrdFOsMdwhG+wHSPyqQcXZagFrJOJctXT0c/KYrsr4A+IcgxrlBU7Hq86CB9vs91YfQTpPqS080wXd8PFE9qpx4N0B+pJ8yy9Lbarlwl3NeQYdxL2j4vbO5NKxJ2Vjbwr4hX5Br86z41Xt/dNI85onDKdSyE5ENPi3a+ejK5zoBvttUO0AQfwpi11CYKG8dVk36tASZg0TEV637ZWPfc/ZGCBuToJ6GNOUBpTzWsxP2q1QPWjqgLhYqxG7g1aS1L2WLV4d9f4lW6sUMj+hTbVFwY4PFK6AMcNCQ/K+WAglntYOF5EV+65J1c4n6l0/YoZCQV6P9bL525KS7LKUIblvH2Xdisa9Vlf7iDO5NWimHZTsdXVuNvdkS2Oy1toLYsxJ9jS8rr2E=
   - secure: RfiNOkv7p2vvUXgTSnzVWSaGhbtjE3oF5wK3p+WPhKn8j/9b9tcBeNZ54J+ipFFH6zs9oJYR93jOIhBJMAKwRzEvOA2JQ69SBO76MUpDaT1s0JhxCSUhA63YWr5PU5uMb6JmRkl08I9JNDM1dPt2BaZeclpTTjq0F6C3eTaOr9wke95ShBtKdrLjCoXKrGYSCx9UYjYz5kmKqt/ROID79rtozJcxhu40wJHzNaTjyVtzy3rfaNG/XcjWBe50rzPHUr+oWnfOyAvVjKoNXEfdC4kiq6UlL+LJLORTpLQa21LGP39XycW07Aom2S/hesTQqII6zJ9pQlQF6auzXnx4PUdpR+BUfz+yzZw2PZ44mMbi3Zd9s0toi6YcPvKKYEPoVtPbSCMJcWWv1nWvd9yzp6dePYTcQ9igeX2zt4rcx1ZplgODCCjwQkkPeE4EoMdYKEQ7f+We3wUQLcuJP+ZUac1Hh+SJ+me9zUy6BrmuvmxHHwJyFPnTd7+Bgdwij6A+aV+K4z30OR57u7sEPBuxhuCBjOFz5BkCGdA4d+E0Z3b8SAg0RKzAuOxqCrmDTeGR5MP5c1FE6N3uBI65P51y083QT8J3QxZLAW+Y4ehd3pO9ErJYqVy2evER3sUZ7/E5uQV3tYxqVdl7+fY1Emjq/VBtgRubqhmxPnttJEjbKeU=
 stages:
@@ -15,8 +15,9 @@ jobs:
     before_script:
     - echo $DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
     script:
-    - docker build -t $DOCKER_IMAGE .
-    - docker push $DOCKER_IMAGE
+    - docker build -t $DOCKER_IMAGE:latest .
+    - docker push $DOCKER_IMAGE:latest
+    - if [ -n "$TRAVIS_TAG" ]; then docker build -t $DOCKER_IMAGE:$TRAVIS_TAG . && docker push $DOCKER_IMAGE:$TRAVIS_TAG; fi
 notifications:
   slack:
     secure: hVWjct1zFlFtargdGlTCGDc/93plZqXo6qe/nrtgNKwoX75ucmrYuAwYO7m/gqrwjoafSJ/aDeT0u4C/bM9P3dBpDWuhc3VXN7ONmGAz42Lo/Ckqg9fOXIFZaUJHig4D2IeyOSAZ9h+NpZfo0Bi3QjOdeeybdEGRe3e2KnKUkQfBQ9sEz2e4iZ3u9QEEAi1q4iEVz7yguJNuITq2oCeXCSMpIzDKaD5MD5YoMRjdWVCKbKL3QVu02Qb8hElhE1FB0pVYwcfh7FB5dE5OpvWdCcBVg3/G3lEZcbTXDzvGepngjtLLcqD3nnDtjZFYotBH/LSXFa/cGYliKT9IbLWkt3CJN+Y7jcVlOxH0ijJnuX0S08jxpNld7S8qtFrN+Bf7MUjuafoeC9fRBNLvQ/kfkzT3kYM/PGmtRzlAuNYhKb1nMmOkG5yTQIcf2wZiTn1/umfD1GLnQ37i65du8+oHcryurStpNP9mi4/drwc6gJNqNrz21lzl7ZlX5xrpJk349XKaT+AHe/Einl6EOM5zwsCVKZ9CBtN45MgnqacXpl2i19JOQ37x23BXU1cUYXbmNDN4Lt/WOHCYXbSbYvVJI9lnyTuGXEgmq4LKwXiUPebfj6PDjeXi7JlhOWdTGftpxbEmCixRl1yiXw2zU8wL2fNvh3GQSXFR8CIbLL24quo=


### PR DESCRIPTION
It’d be nice if we keep each version of Sia release on docker-hub so that we can rollback to a previous version. 

With this PR, Travis CI will build two docker images: one has `latest` tag and the other has git’s tag if available.

When a new Sia version is released, modify `Dockerfile` and tag the commit the release name, then we can keep it on docker-hub.  