### PR TITLE
Pass uncaptured arguments to siad

### DIFF
--- a/run
+++ b/run
@@ -48,7 +48,7 @@ def start(*args, **kwargs):
     modules = "--modules {}".format(kwargs["modules"]) if kwargs["modules"] else ""
     subprocess.run(
         "socat tcp-listen:8000,reuseaddr,fork tcp:localhost:9980 "
-        "& siad --sia-directory {} {}".format(os.getcwd(), modules),
+        "& siad --sia-directory {} {} {}".format(os.getcwd(), modules, " ".join(args)),
         shell=True,
     )
 


### PR DESCRIPTION
It's helpful to pass all uncaptured arguments to siad directly.

For example, if we need to enable profiling, we can use this command: `start --profile cmt --profile-directory ../data`.