### PR TITLE
Catch zlib.error exceptions

### DIFF
--- a/run
+++ b/run
@@ -35,15 +35,18 @@ def start(*args, **kwargs):
     ):
         decompress = zlib.decompressobj(16 + zlib.MAX_WBITS)
         os.makedirs(CONSENSUS_PATH, exist_ok=True)
-        with open(CONSENSUS_FILE, "wb") as output_file, requests.get(DB_URL, stream=True) as r:
-            total = int(r.headers.get("content-length", 0))
+        try:
+            with open(CONSENSUS_FILE, "wb") as output_file, requests.get(DB_URL, stream=True) as r:
+                total = int(r.headers.get("content-length", 0))
 
-            with tqdm(total=total, unit="B", unit_scale=True, unit_divisor=2 ** 10) as pbar:
-                for data in r.iter_content(32 * (2 ** 10)):
-                    output_file.write(decompress.decompress(data))
-                    pbar.update(len(data))
+                with tqdm(total=total, unit="B", unit_scale=True, unit_divisor=2 ** 10) as pbar:
+                    for data in r.iter_content(32 * (2 ** 10)):
+                        output_file.write(decompress.decompress(data))
+                        pbar.update(len(data))
 
-            output_file.write(decompress.flush())
+                output_file.write(decompress.flush())
+        except zlib.error as e:
+            print("Failed to download the bootstrap database: {}".format(e))
 
     modules = "--modules {}".format(kwargs["modules"]) if kwargs["modules"] else ""
     subprocess.run(


### PR DESCRIPTION
While `consensus.db` is being updated, https://consensus.siahub.info/consensus.db.gz might return a broken file and then a zlib.error is thrown. It'd be better to catch the error instead of exiting this program with an error.

